### PR TITLE
feat: show maintenance page when API is down

### DIFF
--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -29,7 +29,7 @@ export default defineAppConfig({
 
         // Redirect to maintenance page if the server is down
         if (ctx.response?.status === 503) {
-          app.runWithContext(() => {
+          app.runWithContext(async () => {
             const currentRoute = app.$router.currentRoute.value.path.replace(/\/$/, '')
             const maintenanceRoute = '/maintenance'
 
@@ -37,7 +37,7 @@ export default defineAppConfig({
               return
             }
 
-            navigateTo(maintenanceRoute)
+            await navigateTo(maintenanceRoute, { external: true })
           })
         }
       },

--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -26,6 +26,20 @@ export default defineAppConfig({
         logger: ConsolaInstance,
       ) => {
         logger.debug(`custom onResponse interceptor (${ctx.request})`)
+
+        // Redirect to maintenance page if the server is down
+        if (ctx.response?.status === 503) {
+          app.runWithContext(() => {
+            const currentRoute = app.$router.currentRoute.value.path.replace(/\/$/, '')
+            const maintenanceRoute = '/maintenance'
+
+            if (currentRoute === maintenanceRoute) {
+              return
+            }
+
+            navigateTo(maintenanceRoute)
+          })
+        }
       },
     },
   },

--- a/app/pages/maintenance.vue
+++ b/app/pages/maintenance.vue
@@ -1,0 +1,72 @@
+<script setup lang="ts">
+definePageMeta({
+  layout: 'minimal',
+})
+
+const
+  HEALTH_CHECK_URL = '/up',
+  HOME_URL = '/'
+
+const sanctumFetch = useSanctumClient()
+const { refreshIdentity } = useSanctumAuth()
+
+const secondsBeforeRedirect = ref(0)
+const canRedirect = computed(() => secondsBeforeRedirect.value === 0)
+
+const redirectButtonText = computed(() => {
+  return canRedirect.value
+    ? 'Try again'
+    : `Try again in ${secondsBeforeRedirect.value} seconds`
+})
+
+function startTimer() {
+  secondsBeforeRedirect.value = 5
+
+  const interval = setInterval(() => {
+    secondsBeforeRedirect.value--
+
+    if (secondsBeforeRedirect.value === 0) {
+      clearInterval(interval)
+    }
+  }, 1000)
+}
+
+async function healthCheck() {
+  try {
+    await sanctumFetch(HEALTH_CHECK_URL)
+
+    try {
+      await refreshIdentity()
+    }
+    catch (error) {
+      // Ignore error if the user is not authenticated
+    }
+
+    await navigateTo(HOME_URL)
+  }
+  catch (error) {
+    startTimer()
+  }
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-4 text-center">
+    <strong class="text-2xl">
+      You got us!
+    </strong>
+    <p>
+      We're currently under maintenance. Please check back later.
+    </p>
+
+    <UButton
+      color="primary"
+      :label="redirectButtonText"
+      class="mx-auto mt-5"
+      :disabled="!canRedirect"
+      @click="healthCheck"
+    />
+  </div>
+</template>
+
+<style scoped></style>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -2,6 +2,8 @@
 export default defineNuxtConfig({
   devtools: { enabled: true },
 
+  ssr: true,
+
   future: {
     compatibilityVersion: 4,
   },


### PR DESCRIPTION
**Is your PR related to a specific issue/feature? Please describe and mention issues.**

This PR adds support for handling the maintenance mode of the Laravel API described in https://github.com/manchenkoff/nuxt-auth-sanctum/issues/130.

**Additional context**

To handle 503 responses, we add a custom interceptor in `app.config.ts` that checks all responses and redirects our users to the`/maintenance` page if they are not already there.

The maintenance page will be shown with a button, that triggers a health check API request (see the `bootstrap/app.php` file of Laravel app). Once the API is up and running, we refresh a user's identity and redirect to the homepage.

**Testing details**

To test this behavior we need to turn down the server by running `php artisan down` and refresh any page to trigger the `nuxt-auth-sanctum` user initial request (or make any other API call resulting in 503 status). 

- [x] tested with basic middleware
- [x] tested with global middleware
- [x] tested with SSR enabled
- [x] tested with SSR disabled

**Reproducing details**

1. With SSR disabled and basic middleware used, a secure page triggers a broken redirect to the login page, while guest pages are still visible w/o redirecting to the maintenance page.
2. With SSR disabled and global middleware used, when we try to reach the secure page we are redirected to the login page instead of the maintenance page. Guest pages are accessible as well.